### PR TITLE
fix: rename API token header to support environments without underscores_in_headers

### DIFF
--- a/credentials/ChatWootApi.credentials.ts
+++ b/credentials/ChatWootApi.credentials.ts
@@ -41,7 +41,7 @@ export class ChatWootApi implements ICredentialType {
         type: 'generic',
         properties: {
             headers: {
-                'api_access_token': '={{$credentials.accessToken}}',
+                'Api-Access-Token': '={{$credentials.accessToken}}',
             },
         },
     };

--- a/nodes/ChatWoot/openapi.json
+++ b/nodes/ChatWoot/openapi.json
@@ -9065,19 +9065,19 @@
       "userApiKey": {
         "type": "apiKey",
         "description": "This token can be obtained by visiting the profile page or via rails console. Provides access to  endpoints based on the user permissions levels. This token can be saved by an external system when user is created via API, to perform activities on behalf of the user.",
-        "name": "api_access_token",
+        "name": "Api-Access-Token",
         "in": "header"
       },
       "agentBotApiKey": {
         "type": "apiKey",
         "description": "This token should be provided by system admin or obtained via rails console. This token can be used to build bot integrations and can only access limited apis.",
-        "name": "api_access_token",
+        "name": "Api-Access-Token",
         "in": "header"
       },
       "platformAppApiKey": {
         "type": "apiKey",
         "description": "This token can be obtained by the system admin after creating a platformApp. This token should be used to provision agent bots, accounts, users and their roles.",
-        "name": "api_access_token",
+        "name": "Api-Access-Token",
         "in": "header"
       }
     }

--- a/nodes/ChatWoot/openapi.json
+++ b/nodes/ChatWoot/openapi.json
@@ -9077,7 +9077,7 @@
       "platformAppApiKey": {
         "type": "apiKey",
         "description": "This token can be obtained by the system admin after creating a platformApp. This token should be used to provision agent bots, accounts, users and their roles.",
-        "name": "Api-Access-Token",
+        "name": "api_access_token",
         "in": "header"
       }
     }

--- a/nodes/ChatWoot/openapi.json
+++ b/nodes/ChatWoot/openapi.json
@@ -9071,7 +9071,7 @@
       "agentBotApiKey": {
         "type": "apiKey",
         "description": "This token should be provided by system admin or obtained via rails console. This token can be used to build bot integrations and can only access limited apis.",
-        "name": "Api-Access-Token",
+        "name": "api_access_token",
         "in": "header"
       },
       "platformAppApiKey": {

--- a/nodes/ChatWoot/openapi.json
+++ b/nodes/ChatWoot/openapi.json
@@ -9065,7 +9065,7 @@
       "userApiKey": {
         "type": "apiKey",
         "description": "This token can be obtained by visiting the profile page or via rails console. Provides access to  endpoints based on the user permissions levels. This token can be saved by an external system when user is created via API, to perform activities on behalf of the user.",
-        "name": "Api-Access-Token",
+        "name": "api_access_token",
         "in": "header"
       },
       "agentBotApiKey": {


### PR DESCRIPTION
Some reverse proxies (like NGINX by default) drop HTTP headers containing underscores, which breaks authentication for Chatwoot API when using api_access_token. This PR renames the header to api-accesstoken (or another supported format) to ensure compatibility without requiring special server configuration (underscores_in_headers on).

    Renamed api_access_token header to api-accesstoken

    Updated documentation and examples accordingly

Fixes issues with 401 errors when running behind NGINX with default settings.