### PR TITLE
fix: text on content type send message in openapi.json

### DIFF
--- a/nodes/ChatWoot/openapi.json
+++ b/nodes/ChatWoot/openapi.json
@@ -8114,8 +8114,9 @@
           "content_type": {
             "type": "string",
             "description": "if you want to create custom message types",
-            "example": "cards",
+            "example": "text",
             "enum": [
+              "text",
               "input_email",
               "cards",
               "input_select",


### PR DESCRIPTION
fix to issue #14 